### PR TITLE
Do not suggest to use sudo npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ During a run, the script will display a graphical progress bar with estimated ti
 Use [npm](https://www.npmjs.com/) to install the module as a command-line executable:
 
 ```
-sudo npm install -g wperf
+npm install -g wperf
 ```
 
 Then call it using `wperf` and specify your URL and options on the command-line:


### PR DESCRIPTION
It's a bad idea. Good explanation: https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92
If it doesn't work without using `sudo`, fix the access permissions: https://stackoverflow.com/a/16151707/1276128